### PR TITLE
Update rest_client_base.py

### DIFF
--- a/tb_rest_client/rest_client_base.py
+++ b/tb_rest_client/rest_client_base.py
@@ -129,7 +129,7 @@ class RestClientBase(Thread):
     def token_login(self, token, refresh_token=None):
         token_json = {
             "token": token,
-            "refresh_token": refresh_token,
+            "refreshToken": refresh_token,
         }
 
         self.__save_token(token_json)


### PR DESCRIPTION
There is a typo in the method, as __save_token() looks for string 'refreshToken'.